### PR TITLE
Extract shared NUM/RAW decode logic into force-inlined helpers

### DIFF
--- a/fastjson_decode.c
+++ b/fastjson_decode.c
@@ -27,6 +27,59 @@
 #include "fastjson_alloc.h"
 #include "yyjson.h"
 
+/* yyjson NUM -> zval. Real -> double; uint <= INT64_MAX -> long; a
+ * larger uint becomes a decimal string under JSON_BIGINT_AS_STRING and
+ * otherwise widens to double (matching ext/json, which never wraps a
+ * uint past LONG_MAX into a negative long); sint -> long. Shared by
+ * both decode walkers and force-inlined so the hot path stays
+ * call-free. */
+static zend_always_inline void fj_num_to_zval(yyjson_val *val,
+                                              zend_long flags, zval *out)
+{
+    if (yyjson_is_real(val)) {
+        ZVAL_DOUBLE(out, yyjson_get_real(val));
+    } else if (yyjson_is_uint(val)) {
+        uint64_t u = yyjson_get_uint(val);
+        if (u <= (uint64_t)ZEND_LONG_MAX) {
+            ZVAL_LONG(out, (zend_long)u);
+        } else if (flags & FASTJSON_DECODE_BIGINT_AS_STRING) {
+            char buf[24];
+            int len = snprintf(buf, sizeof(buf), "%" PRIu64, u);
+            ZVAL_STRINGL(out, buf, (size_t)len);
+        } else {
+            ZVAL_DOUBLE(out, (double)u);
+        }
+    } else { /* SINT */
+        ZVAL_LONG(out, (zend_long)yyjson_get_sint(val));
+    }
+}
+
+/* yyjson RAW -> zval. yyjson emits YYJSON_TYPE_RAW under
+ * YYJSON_READ_BIGNUM_AS_RAW for two distinct cases:
+ *   1. Big integers that overflow int64/uint64. ext/json's
+ *      JSON_BIGINT_AS_STRING wants these as strings; passthrough.
+ *   2. Floats whose exponent overflows a double (e.g. 1e309).
+ *      ext/json decodes those to PHP INF -- BIGINT_AS_STRING does NOT
+ *      apply to floats. Re-parse via strtod so we return the same
+ *      float ext/json would.
+ * Float shape: presence of '.', 'e', or 'E' in the raw text. Shared by
+ * both decode walkers and force-inlined to keep the hot path call-free. */
+static zend_always_inline void fj_raw_to_zval(yyjson_val *val, zval *out)
+{
+    const char *raw = yyjson_get_raw(val);
+    size_t raw_len = yyjson_get_len(val);
+    bool is_float = false;
+    for (size_t i = 0; i < raw_len; i++) {
+        char c = raw[i];
+        if (c == '.' || c == 'e' || c == 'E') { is_float = true; break; }
+    }
+    if (is_float) {
+        ZVAL_DOUBLE(out, zend_strtod(raw, NULL));
+    } else {
+        ZVAL_STRINGL(out, raw, raw_len);
+    }
+}
+
 /* Recursive walker: yyjson_val -> zval. Returns true on success, false
  * on FASTJSON_ERROR_DEPTH (the only mid-walk failure mode). On failure
  * `out` is left as a partial zend_array/zend_object whose
@@ -74,54 +127,12 @@ static bool fastjson_yyval_to_zval(yyjson_val *val, bool assoc,
         return true;
 
     case YYJSON_TYPE_NUM:
-        if (yyjson_is_real(val)) {
-            ZVAL_DOUBLE(out, yyjson_get_real(val));
-        } else if (yyjson_is_uint(val)) {
-            uint64_t u = yyjson_get_uint(val);
-            /* PHP zend_long is signed 64-bit on LP64 builds. uint64
-             * values above LONG_MAX would silently wrap negative if
-             * we cast directly; ext/json's behaviour for that range
-             * is to widen to double. Match it.
-             * JSON_BIGINT_AS_STRING overrides the widen: format the
-             * uint64 as decimal and emit as a PHP string instead. */
-            if (u <= (uint64_t)ZEND_LONG_MAX) {
-                ZVAL_LONG(out, (zend_long)u);
-            } else if (flags & FASTJSON_DECODE_BIGINT_AS_STRING) {
-                char buf[24];
-                int len = snprintf(buf, sizeof(buf), "%" PRIu64, u);
-                ZVAL_STRINGL(out, buf, (size_t)len);
-            } else {
-                ZVAL_DOUBLE(out, (double)u);
-            }
-        } else { /* SINT */
-            ZVAL_LONG(out, (zend_long)yyjson_get_sint(val));
-        }
+        fj_num_to_zval(val, flags, out);
         return true;
 
-    case YYJSON_TYPE_RAW: {
-        /* yyjson emits YYJSON_TYPE_RAW under YYJSON_READ_BIGNUM_AS_RAW
-         * for two distinct cases:
-         *   1. Big integers that overflow int64/uint64. ext/json's
-         *      JSON_BIGINT_AS_STRING wants these as strings; passthrough.
-         *   2. Floats whose exponent overflows a double (e.g. 1e309).
-         *      ext/json decodes those to PHP INF -- BIGINT_AS_STRING
-         *      does NOT apply to floats. Re-parse via strtod so we
-         *      return the same float ext/json would.
-         * Float shape: presence of '.', 'e', or 'E' in the raw text. */
-        const char *raw = yyjson_get_raw(val);
-        size_t raw_len = yyjson_get_len(val);
-        bool is_float = false;
-        for (size_t i = 0; i < raw_len; i++) {
-            char c = raw[i];
-            if (c == '.' || c == 'e' || c == 'E') { is_float = true; break; }
-        }
-        if (is_float) {
-            ZVAL_DOUBLE(out, zend_strtod(raw, NULL));
-        } else {
-            ZVAL_STRINGL(out, raw, raw_len);
-        }
+    case YYJSON_TYPE_RAW:
+        fj_raw_to_zval(val, out);
         return true;
-    }
 
     case YYJSON_TYPE_STR: {
         /* UTF-8 sanitization for JSON_INVALID_UTF8_IGNORE / SUBSTITUTE
@@ -266,35 +277,11 @@ static bool fastjson_yyval_to_zval_sanitize(yyjson_val *val, bool assoc,
         ZVAL_BOOL(out, yyjson_get_bool(val));
         return true;
     case YYJSON_TYPE_NUM:
-        if (yyjson_is_real(val)) {
-            ZVAL_DOUBLE(out, yyjson_get_real(val));
-        } else if (yyjson_is_uint(val)) {
-            uint64_t u = yyjson_get_uint(val);
-            if (u <= (uint64_t)ZEND_LONG_MAX) {
-                ZVAL_LONG(out, (zend_long)u);
-            } else if (flags & FASTJSON_DECODE_BIGINT_AS_STRING) {
-                char buf[24];
-                int len = snprintf(buf, sizeof(buf), "%" PRIu64, u);
-                ZVAL_STRINGL(out, buf, (size_t)len);
-            } else {
-                ZVAL_DOUBLE(out, (double)u);
-            }
-        } else {
-            ZVAL_LONG(out, (zend_long)yyjson_get_sint(val));
-        }
+        fj_num_to_zval(val, flags, out);
         return true;
-    case YYJSON_TYPE_RAW: {
-        const char *raw = yyjson_get_raw(val);
-        size_t raw_len = yyjson_get_len(val);
-        bool is_float = false;
-        for (size_t i = 0; i < raw_len; i++) {
-            char c = raw[i];
-            if (c == '.' || c == 'e' || c == 'E') { is_float = true; break; }
-        }
-        if (is_float) ZVAL_DOUBLE(out, zend_strtod(raw, NULL));
-        else          ZVAL_STRINGL(out, raw, raw_len);
+    case YYJSON_TYPE_RAW:
+        fj_raw_to_zval(val, out);
         return true;
-    }
     case YYJSON_TYPE_STR: {
         const char *raw = yyjson_get_str(val);
         size_t raw_len = yyjson_get_len(val);


### PR DESCRIPTION
## What

De-duplicates the two decode walkers (`fastjson_yyval_to_zval` and `fastjson_yyval_to_zval_sanitize`) by hoisting their byte-identical `YYJSON_TYPE_NUM` and `YYJSON_TYPE_RAW` conversion blocks into two helpers:

- `fj_num_to_zval()` — real → double; uint ≤ INT64_MAX → long; larger uint → string (BIGINT) or widened double; sint → long
- `fj_raw_to_zval()` — raw-float-vs-bignum-string detection

Both are marked `zend_always_inline`, so the compiler flattens them back into each caller and the **branch-free hot path is preserved**. The `STR` and container branches — the parts that genuinely differ between the plain and sanitizing walkers — stay in place.

## Why

The two ~25-line blocks were maintained in lockstep by hand; a fix to either (e.g. the uint/bigint widening rule) had to be applied twice. Single source of truth now.

## Risk

Low. No behavior change intended; the change is a mechanical hoist. Net `-13` lines.

## Verification

- `make` clean, full phpt suite: 96 passed, 0 failed, 2 skipped (unchanged)
- Spot-checked both walkers (the sanitize walker via a UTF-8 flag) on the exact paths touched — identical output:
  - `18446744073709551615` → `float(1.84e19)`; with `JSON_BIGINT_AS_STRING` → `string`
  - `1e309` → `float(INF)`
  - `123456789012345678901234567890` (raw bignum) → `string`
  - `-42` → `int`, `3.14` → `float`

https://claude.ai/code/session_01Fs7oa8xCHnSjvLjyLM6tJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs7oa8xCHnSjvLjyLM6tJB)_