### PR TITLE
Declare ext/json as an optional module dependency for load ordering

### DIFF
--- a/fastjson.c
+++ b/fastjson.c
@@ -470,8 +470,22 @@ PHP_MINFO_FUNCTION(fastjson)
     php_info_print_table_end();
 }
 
+/* Declare ext/json as an OPTIONAL dependency. This is purely a
+ * load-ordering guarantee: when ext/json is present (every standard
+ * PHP build), the engine runs its MINIT before ours, so the
+ * JsonException / JsonSerializable lookups in PHP_MINIT_FUNCTION below
+ * reliably resolve out of CG(class_table) regardless of static-vs-shared
+ * build or registration order. OPTIONAL (not REQUIRED) deliberately
+ * preserves the documented degrade-gracefully behavior when ext/json is
+ * somehow absent: the class-entry pointers stay NULL and fastjson still
+ * loads (throwing \Exception, ignoring JsonSerializable). */
+static const zend_module_dep fastjson_deps[] = {
+    ZEND_MOD_OPTIONAL("json")
+    ZEND_MOD_END
+};
+
 zend_module_entry fastjson_module_entry = {
-    STANDARD_MODULE_HEADER,
+    STANDARD_MODULE_HEADER_EX, NULL, fastjson_deps,
     "fastjson",
     ext_functions,
     PHP_MINIT(fastjson),


### PR DESCRIPTION
## What

Adds a module-dependency array with `ZEND_MOD_OPTIONAL("json")`, wired in via `STANDARD_MODULE_HEADER_EX`.

## Why

`PHP_MINIT_FUNCTION` resolves the `JsonException` and `JsonSerializable` class entries out of `CG(class_table)`, relying on `ext/json`'s MINIT having already run. In the common `extension=fastjson.so` deployment that holds (built-in modules initialize before shared ones), but it was an implicit assumption. Declaring the dependency makes the engine's dependency-ordered startup run json's MINIT before fastjson's **whenever json is present**, so the class-entry resolution is deterministic across static-vs-shared builds and registration order.

## Why OPTIONAL, not REQUIRED

`ZEND_MOD_OPTIONAL` gives the load-ordering guarantee without changing load semantics when json is absent. This deliberately preserves the existing documented behavior (`php_fastjson.h`): on builds where `ext/json` is somehow absent, the class pointers stay `NULL` and fastjson still loads — throwing `\Exception` instead of `\JsonException` and ignoring `JsonSerializable`. `REQUIRED` would refuse to load without json, overriding that intentional degrade-gracefully design.

## Risk

Low. Pure metadata/ordering change.

## Verification

- `make` clean, full phpt suite: 96 passed, 0 failed, 2 skipped (unchanged)
- With the extension loaded: `JsonSerializable` encode works (`fastjson_encode(new S)` → `{"ok":1}`) and `JSON_THROW_ON_ERROR` throws a real `\JsonException` — both confirm json's classes resolve under the new ordering.

https://claude.ai/code/session_01Fs7oa8xCHnSjvLjyLM6tJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fs7oa8xCHnSjvLjyLM6tJB)_