### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -21,7 +21,7 @@ jobs:
       - id: matrix
         uses: php/php-windows-builder/extension-matrix@v1
         with:
-          php-version-list: '8.3, 8.4, 8.5'
+          php-version-list: '8.1, 8.2, 8.3, 8.4, 8.5'
 
   build:
     name: Build ${{ matrix.php-version }} ${{ matrix.ts }} ${{ matrix.arch }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v6
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
       - uses: actions/checkout@v6

--- a/.release-config
+++ b/.release-config
@@ -5,6 +5,8 @@ version_macro: PHP_FASTJSON_VERSION
 version_file: php_fastjson.h
 repo: iliaal/fastjson
 build_matrix:
+  - PHP-8.1
+  - PHP-8.2
   - PHP-8.3
   - PHP-8.4
   - PHP-8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- PHP 8.1 support (lowered the minimum from 8.3).
 - `fastjson_file_decode()` and `fastjson_file_encode()`: read or write a JSON file in one call, collapsing the `fastjson_decode(file_get_contents($f), ...)` and `file_put_contents($f, fastjson_encode(...))` patterns. Signatures mirror the in-memory functions, so `$flags` and `$depth` behave identically:
   - `fastjson_file_decode(string $filename, ?bool $associative = null, int $depth = 512, int $flags = 0): mixed`
   - `fastjson_file_encode(string $filename, mixed $value, int $flags = 0, int $depth = 512): bool`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![fastjson: 6x encode, 2.7x decode, 5x validate vs ext/json](images/fastjson-hero.jpg)
 
-Fast JSON encode, decode, and validate for PHP 8.3+. Drop-in alternative to `ext/json` with a namespaced `fastjson_*` API and `json_last_error`-compatible error reporting. Backed by [yyjson](https://github.com/ibireme/yyjson) 0.12.0, one of the fastest portable JSON libraries. Coexists with `ext/json`; adoption is opt-in per call site.
+Fast JSON encode, decode, and validate for PHP 8.1+. Drop-in alternative to `ext/json` with a namespaced `fastjson_*` API and `json_last_error`-compatible error reporting. Backed by [yyjson](https://github.com/ibireme/yyjson) 0.12.0, one of the fastest portable JSON libraries. Coexists with `ext/json`; adoption is opt-in per call site.
 
 > **Status:** pre-release. yyjson 0.12.0 is vendored and linked. The full `fastjson_encode` / `fastjson_decode` / `fastjson_validate` trio plus `fastjson_last_error` / `_msg` are available. The compat harness against `php-src/ext/json/tests/*.phpt` passes everything targeting features fastjson aims to mirror; the rest is categorized in `tests/upstream-json/.skiplist`.
 
@@ -43,7 +43,7 @@ echo 'extension=fastjson.so' | sudo tee /etc/php/conf.d/fastjson.ini
 
 ### Windows binaries
 
-Pre-built DLLs for PHP 8.3, 8.4, and 8.5 (TS/NTS, x86/x64) are attached to each [GitHub release](https://github.com/iliaal/fastjson/releases).
+Pre-built DLLs for PHP 8.1 through 8.5 (TS/NTS, x86/x64) are attached to each [GitHub release](https://github.com/iliaal/fastjson/releases).
 
 ## 🛠️ Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "iliaal/fastjson",
     "type": "php-ext",
-    "description": "Fast JSON encode/decode/validate for PHP 8.3+, backed by yyjson. Drop-in alternative to ext/json with namespaced fastjson_* functions and json_last_error-compatible error reporting.",
+    "description": "Fast JSON encode/decode/validate for PHP 8.1+, backed by yyjson. Drop-in alternative to ext/json with namespaced fastjson_* functions and json_last_error-compatible error reporting.",
     "keywords": ["json", "yyjson", "decode", "encode", "validate", "performance", "php-extension", "pie"],
     "license": ["BSD-3-Clause", "MIT"],
     "homepage": "https://github.com/iliaal/fastjson",
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.1"
     },
     "php-ext": {
         "extension-name": "fastjson",

--- a/config.m4
+++ b/config.m4
@@ -9,8 +9,8 @@ PHP_ARG_ENABLE(fastjson-dev, whether to enable developer build flags,
 if test "$PHP_FASTJSON" != "no"; then
 
   PHP_VERSION_ID=$($PHP_CONFIG --vernum)
-  if test "$PHP_VERSION_ID" -lt "80300"; then
-    AC_MSG_ERROR([fastjson requires PHP 8.3.0 or later (found $PHP_VERSION_ID)])
+  if test "$PHP_VERSION_ID" -lt "80100"; then
+    AC_MSG_ERROR([fastjson requires PHP 8.1.0 or later (found $PHP_VERSION_ID)])
   fi
 
   YYJSON_SRC_DIR=vendor/yyjson

--- a/fastjson_decode.c
+++ b/fastjson_decode.c
@@ -21,7 +21,14 @@
 #include "php.h"
 #include "php_streams.h"
 #include "ext/standard/file.h"
+#if PHP_VERSION_ID >= 80300
 #include "Zend/zend_call_stack.h"
+#else
+/* zend_call_stack_overflowed() / EG(stack_limit) are 8.3+. On 8.1/8.2
+ * the remaining_depth counter (default 512) still bounds recursion, so
+ * the secondary C-stack check degrades to a no-op. */
+#define zend_call_stack_overflowed(limit) (0)
+#endif
 #include "Zend/zend_exceptions.h"
 #include "Zend/zend_smart_str.h"
 #include "php_fastjson.h"

--- a/fastjson_directwrite.c
+++ b/fastjson_directwrite.c
@@ -49,7 +49,14 @@
 #include <math.h>
 
 #include "php.h"
+#if PHP_VERSION_ID >= 80300
 #include "Zend/zend_call_stack.h"
+#else
+/* zend_call_stack_overflowed() / EG(stack_limit) are 8.3+. On 8.1/8.2
+ * the remaining_depth counter (default 512) still bounds recursion, so
+ * the secondary C-stack check degrades to a no-op. */
+#define zend_call_stack_overflowed(limit) (0)
+#endif
 #include "Zend/zend_exceptions.h"
 #include "Zend/zend_interfaces.h"
 #include "Zend/zend_smart_str.h"

--- a/tests/decode_overflow_with_literal.phpt
+++ b/tests/decode_overflow_with_literal.phpt
@@ -9,6 +9,15 @@ fastjson
 // literals appearing elsewhere in the same input. ext/json rejects
 // these mixed inputs entirely.
 
+// json_validate() is 8.3+; fall back to json_decode parity on 8.1/8.2.
+$ext_json_validate = function (string $json): bool {
+    if (function_exists('json_validate')) {
+        return json_validate($json);
+    }
+    json_decode($json);
+    return json_last_error() === JSON_ERROR_NONE;
+};
+
 foreach ([
     '[1e309, NaN]',
     '[1e309, Infinity]',
@@ -24,7 +33,7 @@ foreach ([
         $j,
         var_export($validate, true),
         var_export($decode === null, true),
-        var_export(json_validate($j), true));
+        var_export($ext_json_validate($j), true));
 }
 
 // Sanity: plain overflow still works.


### PR DESCRIPTION
Lowers the minimum supported PHP from 8.3 to 8.1.

## Blocker and fix

The only API-level blocker was the PHP 8.3 C-stack-overflow check: `Zend/zend_call_stack.h`, `zend_call_stack_overflowed()`, and `EG(stack_limit)` are all 8.3+. Used in `fastjson_decode.c` and `fastjson_directwrite.c`.

Fix: guard the include with `#if PHP_VERSION_ID >= 80300` and define a no-op fallback macro `#define zend_call_stack_overflowed(limit) (0)` for older PHP, so the call sites compile unchanged. The existing `remaining_depth` counter (default 512) still bounds recursion on 8.1/8.2, so dropping the secondary C-stack check there is safe.

## Floor and CI

- `config.m4`: floor `80300` -> `80100`, message updated.
- `composer.json`: `>=8.3` -> `>=8.1` (plus description string).
- README PHP-version lines updated.
- Added 8.1 + 8.2 to the Linux and macOS test matrices, the Windows `php-version-list`, and `.release-config` `build_matrix`.
- `decode_overflow_with_literal.phpt` falls back to `json_decode` parity when `json_validate()` (8.3+) is unavailable.

## Verification

Built `--enable-fastjson-dev` (`-Werror`) and ran the full suite on local ASAN debug builds:

| PHP | Build | Passed | Failed | Skipped |
|-----|-------|--------|--------|---------|
| 8.1.34 | 0 warnings, 0 errors | 101 | 0 | 5 |
| 8.2.31 | 0 warnings, 0 errors | 101 | 0 | 5 |

All 5 skips are benign: four PHP 8.4 property-hook tests, and `gh15168` (stack-overflow) which self-skips via the 8.3+ `zend.max_allowed_stack_size` ini — the expected no-op-path behavior.