### PR TITLE
Fix two ext/json divergences and a 1 MiB encode regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `fastjson_encode()`, `fastjson_file_encode()`, and replacement encoding in `fastjson_pointer_set()` now publish the outer operation's final error state after nested callbacks or destructors call fastjson recursively, matching `ext/json` for success, partial-output, failure, and exception paths.
 - `fastjson_file_encode()` now stops immediately when a userspace stream wrapper throws from `stream_close()`, keeping that exception primary and preserving the applicable error-state contract.
+- `fastjson_decode()` and `fastjson_validate()` no longer reject a string that carries both a backslash escape and invalid UTF-8 under `JSON_INVALID_UTF8_IGNORE`/`SUBSTITUTE`. `"\/\xFFe"` was reported as `unexpected control character in string`; it now decodes to `/e` like `json_decode()`. Raw control characters are still rejected (vendor patch P-004).
+- A non-finite number without `JSON_PARTIAL_OUTPUT_ON_ERROR` keeps traversing so a later error can take precedence, as `ext/json` does — but that walk now stops where `ext/json` stops. Previously an error nested inside the failing container did not end the walk, so `fastjson_encode([[INF, "\xB1\x31"], INF])` reported `JSON_ERROR_INF_OR_NAN` where `json_encode()` reports `JSON_ERROR_UTF8`, and `JsonSerializable::jsonSerialize()` could be invoked on values `ext/json` never reaches.
+- `fastjson_pointer_get()` and `fastjson_pointer_exists()` reject a pointer whose traversed path is made ambiguous by duplicate object members instead of silently selecting the first, while full decode keeps `ext/json`'s last-wins behaviour. Duplicates away from the path are still accepted.
+- `fastjson_pointer_set()` preserves untouched number lexemes byte-for-byte, so large integers, `-0`, and trailing-zero forms survive a set elsewhere in the document, and replacement values are spliced without an encode/parse/write round trip that normalised `-0`.
+- `fastjson_pointer_set()` validates pointer syntax, traversal, and the settable location before serialising the replacement, so a malformed or non-settable pointer no longer invokes `JsonSerializable` callbacks first.
+- `fastjson_pointer_set()` and `fastjson_merge_patch()` apply `$depth` to the effective result rather than to input branches the operation discards.
+- `fastjson_file_decode()` reports a read failure when a stream wrapper returns a terminal error after valid JSON while also reporting EOF, instead of decoding the bytes read so far.
+- `fastjson_file_decode()` ignores a stream wrapper's declared size for non-stdio streams, so a wrapper claiming 64 MiB for an 11-byte body can no longer exhaust `memory_limit`.
+- The `JsonSerializable` recursion guard is released before the `jsonSerialize()` result is destroyed, so a destructor that re-enters encoding no longer sees a false `JSON_ERROR_RECURSION`.
+
+### Performance
+
+Measured against 0.6.0 on PHP 8.4 release builds (x86_64; aarch64 where noted).
+
+- `fastjson_merge_patch()` is ~95% faster on a 2,000-key merge: the mutable result is walked into zvals directly instead of being copied into an immutable document first, and duplicate-heavy objects use a hash index rather than repeated linear lookups.
+- Large clean-ASCII `fastjson_encode()` is 32–66% faster (256 KiB – 1 MiB); a large string whose first escape appears late reuses the clean prefix instead of rescanning (`encode_late_quote_512k` −70%).
+- Tolerant decode (`JSON_INVALID_UTF8_IGNORE`/`SUBSTITUTE`) is 20–64% faster on clean input: vendor patch P-005 tags strings the parser saw as malformed, so the sanitising walker only runs when it is needed.
+- Packed-array decode is ~22% faster and object decode ~11% faster (Zend packed fill, pre-sized `stdClass` property tables).
+- `fastjson_pointer_set()` is 42–66% faster depending on shape, and parse-error position reporting on ASCII input is ~51% faster.
+- Top-level `null`, `true`, integer, and double encoding skip the `smart_str` buffer entirely (35–43% faster).
+- `fastjson_file_decode()` is ~7% faster on a 16 MiB document.
+- A non-finite number without `JSON_PARTIAL_OUTPUT_ON_ERROR` frees the buffered output immediately instead of accumulating a tail it will discard: `[INF, <32 MiB string>]` drops from 33.5 MB of extra peak memory to zero.
+- The exact-size preflight for very large strings now starts at 8 MiB rather than 1 MiB. Below that the writer takes its single-pass path: at 1 MiB the second pass cost more than the reservation it saved (+75% on x86_64, +160% on aarch64 for UTF-8 text).
+
+### Build
+
+- `vendor/yyjson/` local patches P-001 through P-005 are stored as a replayable patch series verified against pristine yyjson 0.12.0 in CI, instead of prose-only descriptions.
+- Project metadata verification compares the stub hash embedded in `fastjson_arginfo.h` against `fastjson.stub.php`.
+- GitHub Actions workflows pin every action by commit SHA, default to `permissions: {}` with per-job least privilege, disable credential persistence, and verify that a release build checks out the tag it claims. PHP 8.6 joins the source-build matrix.
 
 ## [0.6.0] - 2026-07-09
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -21,6 +21,46 @@ php -d extension=... bench/run.php bench/data 200
 The output is markdown. Pipe to a file to capture, or just commit
 `bench/baseline.md` after a clean run.
 
+## Review-performance harness
+
+`bench/run.php` measures the corpus files; it does not cover the paths most
+often touched by tuning work. `bench/review-performance.php` does: large-string
+encode across the threshold boundaries, pointer splice, merge patch, tolerant
+decode, and parse-error position reporting. Its committed reference is
+`bench/review-baseline.md`.
+
+```sh
+php -d extension=$(pwd)/modules/fastjson.so bench/review-performance.php \
+    [samples] [target_ms] [/case-name-regex/]
+```
+
+It validates each selected case's result before timing it and exits non-zero on
+an invalid or unmatched filter, so a case that starts returning `false` cannot
+read as a speedup.
+
+**Compare releases, not sessions.** Absolute numbers move with machine load;
+two runs minutes apart can differ by 40% on the same binary. Build the previous
+release and the working tree, then alternate them in one session and take the
+best of each:
+
+```sh
+git worktree add ../fj-prev <previous-tag>
+(cd ../fj-prev && phpize && ./configure --enable-fastjson \
+    --with-php-config=$(which php-config) && make -j$(nproc))
+
+for pass in 1 2; do
+  for so in "$(pwd)/modules/fastjson.so" ../fj-prev/modules/fastjson.so; do
+    taskset -c 4 php -d extension="$so" -d memory_limit=-1 \
+        bench/review-performance.php 9 100 > "bench-$(basename $(dirname $(dirname $so)))-$pass.json"
+  done
+done
+```
+
+Interleaving the two builds is what makes the comparison trustworthy: it cancels
+thermal drift and background load that a sequential A-then-B run attributes to
+the code. Check ARM too when a change tunes a scan/copy trade-off — the
+crossover points differ from x86_64.
+
 ## Methodology
 
 - **Latest baseline:** 100 iterations of `(encode | decode | validate)` on each

--- a/bench/review-baseline.md
+++ b/bench/review-baseline.md
@@ -1,0 +1,58 @@
+# Review-performance baseline
+
+Per-case medians from `bench/review-performance.php`, the harness that covers
+the paths `bench/run.php` does not: large-string encode, pointer splice, merge
+patch, tolerant decode, and parse-error position reporting.
+
+- PHP 8.4.22-dev (NTS release build)
+- CPU: 13th Gen Intel(R) Core(TM) i9-13950HX
+- 9 samples per case, 100 ms target, best of 2 interleaved passes, `taskset` pinned
+- Reference: fastjson 0.6.0 built from the same tree against the same PHP
+
+Absolute nanoseconds are machine-specific and are not a pass/fail gate. The
+column that matters is the delta against the previous release, measured in the
+same session (see bench/README.md).
+
+| case | 0.6.0 (ns) | current (ns) | delta |
+|---|---:|---:|---:|
+| `merge_patch_2k` | 6,233,647 | 337,987 | -94.6% |
+| `pointer_set_string_1m` | 609,247 | 217,005 | -64.4% |
+| `encode_ascii_512k` | 280,068 | 99,968 | -64.3% |
+| `encode_late_quote_512k` | 273,852 | 99,377 | -63.7% |
+| `decode_tolerant_clean_1m` | 967,856 | 361,768 | -62.6% |
+| `encode_ascii_below_1m` | 558,165 | 216,079 | -61.3% |
+| `encode_ascii_1m` | 549,590 | 212,866 | -61.3% |
+| `pointer_set_root_array_10k` | 209,585 | 103,340 | -50.7% |
+| `decode_error_tail_512k` | 377,460 | 190,975 | -49.4% |
+| `encode_true` | 46 | 27 | -41.1% |
+| `encode_null` | 46 | 28 | -39.8% |
+| `encode_ascii_256k` | 75,237 | 49,116 | -34.7% |
+| `encode_int` | 51 | 35 | -32.3% |
+| `pointer_set_array_10k` | 267,380 | 183,292 | -31.4% |
+| `encode_late_quote_256k` | 72,736 | 49,945 | -31.3% |
+| `decode_tolerant_invalid_tail_1m` | 1,970,176 | 1,448,933 | -26.5% |
+| `decode_tolerant_strings_8b` | 893,367 | 707,888 | -20.8% |
+| `decode_tolerant_strings_1b` | 2,168,228 | 1,776,136 | -18.1% |
+| `decode_packed_scalar_10k` | 95,069 | 79,719 | -16.1% |
+| `encode_double` | 61 | 54 | -11.9% |
+| `file_decode_16m` | 27,287,686 | 25,190,867 | -7.7% |
+| `decode_packed_mixed_2k` | 136,167 | 126,138 | -7.4% |
+| `encode_unicode_512k` | 820,693 | 761,955 | -7.2% |
+| `encode_hex_32k` | 78,524 | 73,056 | -7.0% |
+| `decode_object_5k` | 137,926 | 128,730 | -6.7% |
+| `encode_unicode_256k` | 212,665 | 200,437 | -5.7% |
+| `encode_unicode_1m` | 1,693,539 | 1,630,009 | -3.8% |
+| `encode_unicode_128k` | 104,468 | 101,636 | -2.7% |
+| `encode_ascii_64k` | 18,699 | 18,221 | -2.6% |
+| `encode_escaped_1m` | 1,814,503 | 1,783,199 | -1.7% |
+| `encode_ascii_below_256k` | 75,708 | 74,715 | -1.3% |
+| `encode_ascii_128k` | 36,912 | 36,569 | -0.9% |
+| `validate_strings_1b` | 246,172 | 244,288 | -0.8% |
+| `decode_assoc_object_5k` | 119,916 | 120,093 | +0.1% |
+| `file_get_plus_decode_16m` | 25,356,187 | 25,452,534 | +0.4% |
+| `pointer_set_hex_32k` | 76,051 | 76,514 | +0.6% |
+| `encode_escaped_128k` | 136,376 | 137,356 | +0.7% |
+| `encode_escaped_256k` | 421,947 | 425,491 | +0.8% |
+| `encode_escaped_512k` | 855,056 | 865,190 | +1.2% |
+| `validate_strings_8b` | 222,129 | 227,828 | +2.6% |
+| `pointer_set_leaf` | 109,891 | 114,477 | +4.2% |

--- a/fastjson_directwrite.c
+++ b/fastjson_directwrite.c
@@ -70,6 +70,12 @@ typedef struct fastjson_dw_ctx {
     bool            partial_output;
     bool            pretty_print;
     bool            hard_error;
+    /* Set once a discard walk hits an error that ext/json treats as a hard
+     * stop. ext/json propagates that FAILURE out of every enclosing
+     * container, so no further siblings are visited; without this flag each
+     * enclosing level would start its own discard and report an error from a
+     * value ext/json never reached (and re-enter JsonSerializable). */
+    bool            discard_aborted;
     fastjson_error_state error;
     uint32_t        call_depth;
     int             indent_level;  /* current pretty-print depth; 0 at
@@ -543,7 +549,7 @@ static zend_never_inline bool dw_emit_array(fastjson_dw_ctx *ctx, HashTable *ht,
             if (pretty) dw_emit_newline_indent(ctx, ctx->indent_level);
             if (UNEXPECTED(!dw_encode_zval(
                     ctx, item, remaining_depth - 1))) {
-                if (ctx->hard_error) {
+                if (ctx->hard_error && !ctx->discard_aborted) {
 #if PHP_VERSION_ID < 80200
                     uint32_t from = (uint32_t)((_p + 1) - __ht->arData);
 #else
@@ -551,8 +557,10 @@ static zend_never_inline bool dw_emit_array(fastjson_dw_ctx *ctx, HashTable *ht,
                         ? (uint32_t)((_z + 1) - __ht->arPacked)
                         : (uint32_t)(((Bucket *)_z + 1) - __ht->arData);
 #endif
-                    (void)dw_discard_array_range(ctx, ht, from,
-                        remaining_depth - 1, true);
+                    if (!dw_discard_array_range(ctx, ht, from,
+                            remaining_depth - 1, true)) {
+                        ctx->discard_aborted = true;
+                    }
                 }
                 if (need_recursion_guard) GC_UNPROTECT_RECURSION(ht);
                 if (pretty && !empty) ctx->indent_level--;
@@ -570,7 +578,7 @@ static zend_never_inline bool dw_emit_array(fastjson_dw_ctx *ctx, HashTable *ht,
             if (pretty) dw_emit_newline_indent(ctx, ctx->indent_level);
             if (UNEXPECTED(!dw_emit_object_key(ctx, key, index)
                     || !dw_encode_zval(ctx, item, remaining_depth - 1))) {
-                if (ctx->hard_error) {
+                if (ctx->hard_error && !ctx->discard_aborted) {
 #if PHP_VERSION_ID < 80200
                     uint32_t from = (uint32_t)((_p + 1) - __ht->arData);
 #else
@@ -578,8 +586,10 @@ static zend_never_inline bool dw_emit_array(fastjson_dw_ctx *ctx, HashTable *ht,
                         ? (uint32_t)(__z - __ht->arPacked)
                         : (uint32_t)((Bucket *)__z - __ht->arData);
 #endif
-                    (void)dw_discard_array_range(ctx, ht, from,
-                        remaining_depth - 1, false);
+                    if (!dw_discard_array_range(ctx, ht, from,
+                            remaining_depth - 1, false)) {
+                        ctx->discard_aborted = true;
+                    }
                 }
                 if (need_recursion_guard) GC_UNPROTECT_RECURSION(ht);
                 if (pretty && !empty) ctx->indent_level--;
@@ -814,7 +824,7 @@ static bool dw_emit_object_props(fastjson_dw_ctx *ctx, zval *zv,
         if (pretty) dw_emit_newline_indent(ctx, ctx->indent_level);
         if (UNEXPECTED(!dw_emit_object_key(ctx, key, index)
                 || !dw_encode_zval(ctx, item, remaining_depth - 1))) {
-            if (ctx->hard_error) {
+            if (ctx->hard_error && !ctx->discard_aborted) {
 #if PHP_VERSION_ID < 80200
                 uint32_t from = (uint32_t)((_p + 1) - __ht->arData);
 #else
@@ -825,8 +835,10 @@ static bool dw_emit_object_props(fastjson_dw_ctx *ctx, zval *zv,
                     zval_ptr_dtor(&hook_rv);
                     release_hook_rv = false;
                 }
-                (void)dw_discard_object_props_range(ctx, obj, props, from,
-                    remaining_depth - 1);
+                if (!dw_discard_object_props_range(ctx, obj, props, from,
+                        remaining_depth - 1)) {
+                    ctx->discard_aborted = true;
+                }
             }
             if (release_hook_rv) zval_ptr_dtor(&hook_rv);
             if (need_recursion_guard) GC_UNPROTECT_RECURSION(recursion_rc);

--- a/php_fastjson.h
+++ b/php_fastjson.h
@@ -311,8 +311,28 @@ bool fastjson_apply_hex_escapes(smart_str *buf, zend_long flags,
     (((flags) & (FASTJSON_INVALID_UTF8_IGNORE \
                  | FASTJSON_INVALID_UTF8_SUBSTITUTE)) != 0)
 
+/* At and above this length a string is routed to
+ * fastjson_write_large_json_string(), which scans for escape candidates and
+ * then copies, rather than letting yyjson's writer reserve 6x and fuse both
+ * steps into one pass. Trading a second pass for a much smaller reservation
+ * is strongly positive on x86_64 (clean 256 KiB ASCII -35%, a late escape
+ * -31%) and mildly negative on aarch64 (+8%), where the extra pass costs more
+ * than the allocation it saves; by 512 KiB both architectures are ~40% ahead.
+ * Kept at 256 KiB deliberately: the x86_64 win is several times the aarch64
+ * cost and the crossover is only one step away on ARM. Re-measure on both
+ * architectures before moving it. */
 #define FASTJSON_EXACT_STRING_THRESHOLD (256 * 1024)
-#define FASTJSON_EXACT_NONASCII_THRESHOLD (1024 * 1024)
+/* Above this length a string that is not copyable ASCII pays an exact-size
+ * preflight (a second full pass over the input) so the writer reserves the
+ * real output size instead of the 6x worst case. For anything but clean
+ * ASCII that second pass costs about as much as the write itself -- measured
+ * +75% (x86_64) and +160% (aarch64) on a 1 MiB UTF-8 string -- so it is only
+ * worth paying once the 6x reservation is itself a memory hazard. At 8 MiB
+ * the avoided reservation is 48 MiB, which is where it starts to threaten a
+ * default 128M memory_limit. Below it, take the 6x reservation and one pass.
+ * Clean ASCII never reaches the preflight: the fused scan-and-copy loop in
+ * fastjson_write_large_json_string() completes it in a single pass. */
+#define FASTJSON_EXACT_NONASCII_THRESHOLD (8 * 1024 * 1024)
 #define FASTJSON_ENCODE_HEX_MASK (FASTJSON_ENCODE_HEX_TAG \
     | FASTJSON_ENCODE_HEX_AMP | FASTJSON_ENCODE_HEX_APOS \
     | FASTJSON_ENCODE_HEX_QUOT)

--- a/tests/decode_invalid_utf8_after_escape.phpt
+++ b/tests/decode_invalid_utf8_after_escape.phpt
@@ -1,0 +1,102 @@
+--TEST--
+fastjson_decode: invalid UTF-8 stays tolerated in strings that carry an escape
+--EXTENSIONS--
+fastjson
+--FILE--
+<?php
+
+/* A backslash escape switches yyjson's string reader from its skip path to
+ * its copy path. On the copy path a byte tolerated by ALLOW_INVALID_UTF8 is
+ * copied through and the reader re-enters copy_utf8, which routes the next
+ * ordinary ASCII byte to copy_escape. That arm must copy the byte and carry
+ * on -- it is not a control character. Vendor patch P-004 must keep rejecting
+ * genuine control bytes without capturing this case. */
+
+$cases = [
+    '"\\/' . "\xFF" . 'e"',
+    '"a\\nb' . "\xFF" . 'c"',
+    '"\\t' . "\xC3" . '.tail"',
+    '"\\u0041' . "\xFF" . 'z"',
+    '"\\\\' . "\xE0" . '.x"',
+    // invalid byte last, before the closing quote (skip-path equivalent)
+    '"a\\n' . "\xFF" . '"',
+    // no escape at all: the skip path, already correct before the fix
+    '"a' . "\xFF" . 'b"',
+    // several invalid bytes interleaved with ordinary text
+    '"\\n' . "\xFF" . 'a' . "\xC3" . 'b' . "\xF5" . 'c"',
+];
+
+foreach ([JSON_INVALID_UTF8_IGNORE, JSON_INVALID_UTF8_SUBSTITUTE] as $flag) {
+    foreach ($cases as $json) {
+        $native = json_decode($json, true, 512, $flag);
+        $fast = fastjson_decode($json, true, 512, $flag);
+        var_dump($fast === $native);
+        var_dump($fast);
+    }
+}
+
+/* Raw control characters are still rejected on the copy path. */
+var_dump(fastjson_decode('"a\\nb' . "\x01" . 'c"', true, 512, JSON_INVALID_UTF8_IGNORE));
+echo fastjson_last_error_msg(), "\n";
+
+/* Without a UTF-8 handling flag the invalid byte is still an error. */
+var_dump(fastjson_decode('"\\/' . "\xFF" . 'e"', true, 512, 0));
+var_dump(fastjson_last_error() === JSON_ERROR_UTF8);
+
+/* fastjson_validate() agrees with json_validate() on the same inputs. */
+foreach ($cases as $json) {
+    var_dump(fastjson_validate($json, 512, JSON_INVALID_UTF8_IGNORE)
+        === json_validate($json, 512, JSON_INVALID_UTF8_IGNORE));
+}
+?>
+--EXPECT--
+bool(true)
+string(2) "/e"
+bool(true)
+string(4) "a
+bc"
+bool(true)
+string(6) "	.tail"
+bool(true)
+string(2) "Az"
+bool(true)
+string(3) "\.x"
+bool(true)
+string(2) "a
+"
+bool(true)
+string(2) "ab"
+bool(true)
+string(4) "
+abc"
+bool(true)
+string(5) "/�e"
+bool(true)
+string(7) "a
+b�c"
+bool(true)
+string(9) "	�.tail"
+bool(true)
+string(5) "A�z"
+bool(true)
+string(6) "\�.x"
+bool(true)
+string(5) "a
+�"
+bool(true)
+string(5) "a�b"
+bool(true)
+string(13) "
+�a�b�c"
+NULL
+unexpected control character in string
+NULL
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/decode_invalid_utf8_after_escape.phpt
+++ b/tests/decode_invalid_utf8_after_escape.phpt
@@ -43,10 +43,13 @@ echo fastjson_last_error_msg(), "\n";
 var_dump(fastjson_decode('"\\/' . "\xFF" . 'e"', true, 512, 0));
 var_dump(fastjson_last_error() === JSON_ERROR_UTF8);
 
-/* fastjson_validate() agrees with json_validate() on the same inputs. */
+/* fastjson_validate() agrees with ext/json on the same inputs. json_validate()
+ * is 8.3+, so use json_decode()'s error state as the oracle instead. */
 foreach ($cases as $json) {
+    json_decode($json, true, 512, JSON_INVALID_UTF8_IGNORE);
+    $nativeValid = json_last_error() === JSON_ERROR_NONE;
     var_dump(fastjson_validate($json, 512, JSON_INVALID_UTF8_IGNORE)
-        === json_validate($json, 512, JSON_INVALID_UTF8_IGNORE));
+        === $nativeValid);
 }
 ?>
 --EXPECT--

--- a/tests/encode_error_precedence_abort.phpt
+++ b/tests/encode_error_precedence_abort.phpt
@@ -1,0 +1,96 @@
+--TEST--
+fastjson_encode: a hard-stop error inside the discard walk ends the traversal
+--EXTENSIONS--
+fastjson
+--FILE--
+<?php
+
+/* A non-partial INF/NAN frees the buffer and keeps traversing so a later error
+ * can take precedence, as ext/json does. ext/json aborts that walk as soon as a
+ * nested value returns FAILURE (invalid UTF-8, recursion, unsupported type), so
+ * containers outside the failing one are never visited. The discard walk has to
+ * stop at the same point: otherwise the reported error code comes from a value
+ * ext/json never reached, and JsonSerializable callbacks fire spuriously. */
+
+class Probe implements JsonSerializable
+{
+    public static int $calls = 0;
+
+    public function jsonSerialize(): mixed
+    {
+        self::$calls++;
+        return 1;
+    }
+}
+
+$bad = "\xB1\x31";
+$resource = fopen('php://memory', 'r');
+$recursive = [];
+$recursive[] = &$recursive;
+
+$cases = [
+    [[[INF, $bad], INF]],
+    [[[INF, $bad], NAN]],
+    [['a' => [INF, $bad], 'b' => INF]],
+    [[[INF, $bad], $resource]],
+    [[[INF, $bad], $recursive]],
+    [[[[INF, $bad]], INF]],
+    [(object)['a' => [INF, $bad], 'b' => INF]],
+    [[[INF, $bad], [[[1]]]]],
+];
+
+foreach ($cases as [$value]) {
+    json_encode($value);
+    $native = json_last_error();
+    var_dump(fastjson_encode($value));
+    var_dump(fastjson_last_error() === $native);
+}
+
+/* Callback counts must match ext/json exactly. */
+$callbackCases = [
+    static fn() => [[INF, $bad], new Probe()],
+    static fn() => ['a' => [INF, $bad], 'b' => new Probe()],
+    static fn() => [[[INF, $bad]], new Probe()],
+    static fn() => [[INF], new Probe()],
+    static fn() => [new Probe(), new Probe()],
+];
+
+foreach ($callbackCases as $make) {
+    Probe::$calls = 0;
+    json_encode($make());
+    $nativeCalls = Probe::$calls;
+    Probe::$calls = 0;
+    fastjson_encode($make());
+    var_dump(Probe::$calls === $nativeCalls);
+}
+
+/* PARTIAL_OUTPUT keeps the buffered walk and is unaffected. */
+var_dump(fastjson_encode([[INF, $bad], INF], JSON_PARTIAL_OUTPUT_ON_ERROR)
+    === json_encode([[INF, $bad], INF], JSON_PARTIAL_OUTPUT_ON_ERROR));
+
+fclose($resource);
+unset($recursive);
+?>
+--EXPECT--
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/vendor/yyjson/PATCHES.md
+++ b/vendor/yyjson/PATCHES.md
@@ -203,6 +203,19 @@ handled on a *separate* path (the non-ASCII branch, message
 `ALLOW_INVALID_UNICODE`. Only the control-char branch is made
 unconditional.
 
+**This arm is not reached for control characters alone.** The reader has
+two string paths: a non-copying `skip_*` path, and a `copy_*` path it
+switches to once an escape appears. On the copy path, `copy_utf8` sends a
+byte tolerated by `ALLOW_INVALID_UNICODE` to `copy_ascii_stop_1`, which
+copies that byte and re-enters `copy_utf8`; the next *ordinary* ASCII byte
+then arrives in this arm via `goto copy_escape`. So the branch must test the
+control range explicitly and let everything else fall through to upstream's
+byte copy. Rejecting unconditionally instead broke any string that carried
+both a backslash escape and an invalid UTF-8 byte with more text after it —
+`"\/\xFFe"` under `JSON_INVALID_UTF8_IGNORE` was reported as
+`"unexpected control character in string"` where ext/json decodes `/e`.
+Covered by `tests/decode_invalid_utf8_after_escape.phpt`.
+
 **Patch.** Replace the flag-gated control-char branch:
 
 ```c
@@ -215,14 +228,15 @@ unconditional.
     }
 ```
 
-with an unconditional rejection (unclosed strings are already caught
-earlier as `"unexpected end of data"`, so only genuine control chars
-reach here):
+with a rejection scoped to the control range, keeping the byte copy:
 
 ```c
     } else {
         if (src >= eof) return_err(src, "unclosed string");
-        return_err(src, "unexpected control character in string");
+        if (unlikely(*src < 0x20)) {
+            return_err(src, "unexpected control character in string");
+        }
+        *dst++ = *src++;
     }
 ```
 

--- a/vendor/yyjson/patches/0004-reject-control-characters.patch
+++ b/vendor/yyjson/patches/0004-reject-control-characters.patch
@@ -1,75 +1,49 @@
-From e4e8fd77e0cf6e98c1b30663fdc37c8ac3617f91 Mon Sep 17 00:00:00 2001
-From: Ilia Alshanetsky <ilia@ilia.ws>
-Date: Thu, 9 Jul 2026 14:15:18 -0400
-Subject: [PATCH] Fix encode UAF, JsonSerializable semantics, pointer_set
- edges, CI masking
+Subject: [PATCH] P-004: reject raw control characters in JSON strings
 
-Correctness:
-- Fix an encode use-after-free when a nested JsonSerializable mutates the
-  array being encoded through an aliasing &-reference (append reallocates
-  arData mid-iteration). Hold a reference across the array descent so the
-  mutation copies-on-write away, mirroring ext/json's json_encode_zval
-  IS_ARRAY guard. Confirmed under valgrind with USE_ZEND_ALLOC=0.
-- JsonSerializable::jsonSerialize() returning $this now encodes the
-  object's public properties instead of a false JSON_ERROR_RECURSION.
-- JsonSerializable no longer charges the serialize call an extra depth
-  level: a jsonSerialize() returning an M-deep value needs $depth >= M,
-  matching ext/json. Fixes both the returns-$this and returns-a-fresh-value
-  paths.
-- Reject raw control characters in strings under JSON_INVALID_UTF8_IGNORE/
-  SUBSTITUTE in both fastjson_decode() and fastjson_validate(); those flags
-  relax UTF-8 validity only. Fixed in the yyjson reader (vendor patch
-  P-004) so every decode path is covered and RELAXED comments are handled
-  correctly. Invalid UTF-8 stays tolerated.
-- pointer_set(): reject re-emitting a non-finite number (an untouched
-  1e309 that decoded to INF) as invalid Infinity; fail with
-  JSON_ERROR_INF_OR_NAN instead.
-- pointer_set(): count the pointer path against the replacement depth
-  budget so it cannot emit a document deeper than $depth.
-- pointer_set(): guard the array-index parser against 32-bit size_t
-  overflow.
+JSON_INVALID_UTF8_IGNORE / JSON_INVALID_UTF8_SUBSTITUTE map to yyjson's
+YYJSON_READ_ALLOW_INVALID_UNICODE, which upstream also lets tolerate raw
+control bytes inside strings. ext/json rejects those regardless of its
+JSON_INVALID_UTF8_* flags (JSON_ERROR_CTRL_CHAR), so re-impose the strict
+check in the reader, where every decode path and fastjson_validate() share it
+and RELAXED comments are handled correctly.
 
-Compat harness:
-- The returns-$this handling and the array-copy guard make
-  json_encode_recursion_01/02 and bug77843 pass byte-for-byte; un-skipped
-  (rewritten set 62 -> 65).
-
-For contributors (CI/build):
-- The Linux build step propagates a failing make via pipefail instead of
-  swallowing it behind a warning grep; the test steps assert the extension
-  actually loaded; the ASAN step keeps the runner exit status and checks
-  leaked/borked/no-summary, not just "Tests failed".
-- scripts/pie-smoke.sh reports and exits non-zero when PIE itself fails,
-  instead of printing PASSED after the manual phpize fallback.
----
- vendor/yyjson/yyjson.c | 13 +++++++++----
- 1 file changed, 9 insertions(+), 4 deletions(-)
+Test only the control range (< 0x20). This arm is not reached exclusively for
+control characters: on the copy path, copy_utf8 routes a byte tolerated by
+ALLOW_INVALID_UNICODE to copy_ascii_stop_1, which copies it and re-enters
+copy_utf8, so the next ordinary ASCII byte arrives here via `goto copy_escape`.
+Anything outside the control range keeps upstream's byte copy; rejecting it
+would misreport a tolerated invalid UTF-8 byte followed by more text as a
+control character.
 
 diff --git a/vendor/yyjson/yyjson.c b/vendor/yyjson/yyjson.c
-index c9d272e..0215e49 100644
+index c9d272e..760a706 100644
 --- a/vendor/yyjson/yyjson.c
 +++ b/vendor/yyjson/yyjson.c
-@@ -4935,11 +4935,16 @@ copy_escape:
+@@ -4935,10 +4935,25 @@ copy_escape:
          if (con) con[0] = con[1] = NULL;
          return true;
      } else {
 -        if (!has_allow(INVALID_UNICODE)) {
--            return_err(src, "unexpected control character in string");
--        }
 +        /* fastjson patch P-004: reject raw control characters in strings
 +         * even under ALLOW_INVALID_UNICODE. That flag is meant to relax
 +         * UTF-8 validity only (handled on the high-byte path above); a
 +         * literal control byte (< 0x20) is a JSON-grammar violation that
 +         * ext/json always rejects (JSON_ERROR_CTRL_CHAR) regardless of its
-+         * JSON_INVALID_UTF8_* flags. Unclosed strings are caught earlier as
-+         * "unexpected end of data", so only genuine control chars reach here.
-+         * Original upstream tolerated them here under the flag. */
-         if (src >= eof) return_err(src, "unclosed string");
--        *dst++ = *src++;
-+        return_err(src, "unexpected control character in string");
++         * JSON_INVALID_UTF8_* flags. Original upstream tolerated them here
++         * under the flag.
++         *
++         * This arm is NOT reached for control characters only. On the copy
++         * path, copy_utf8 sends a byte tolerated by ALLOW_INVALID_UNICODE to
++         * copy_ascii_stop_1, which copies it and re-enters copy_utf8; the
++         * next ordinary ASCII byte then arrives here via `goto copy_escape`.
++         * Test only the control range and let anything else copy through as
++         * upstream did, or a tolerated invalid byte followed by more text is
++         * misreported as a control character. */
++        if (src >= eof) return_err(src, "unclosed string");
++        if (unlikely(*src < 0x20)) {
+             return_err(src, "unexpected control character in string");
+         }
+-        if (src >= eof) return_err(src, "unclosed string");
+         *dst++ = *src++;
      }
  
- copy_ascii:
--- 
-2.34.1
-

--- a/vendor/yyjson/yyjson.c
+++ b/vendor/yyjson/yyjson.c
@@ -4952,11 +4952,21 @@ copy_escape:
          * UTF-8 validity only (handled on the high-byte path above); a
          * literal control byte (< 0x20) is a JSON-grammar violation that
          * ext/json always rejects (JSON_ERROR_CTRL_CHAR) regardless of its
-         * JSON_INVALID_UTF8_* flags. Unclosed strings are caught earlier as
-         * "unexpected end of data", so only genuine control chars reach here.
-         * Original upstream tolerated them here under the flag. */
+         * JSON_INVALID_UTF8_* flags. Original upstream tolerated them here
+         * under the flag.
+         *
+         * This arm is NOT reached for control characters only. On the copy
+         * path, copy_utf8 sends a byte tolerated by ALLOW_INVALID_UNICODE to
+         * copy_ascii_stop_1, which copies it and re-enters copy_utf8; the
+         * next ordinary ASCII byte then arrives here via `goto copy_escape`.
+         * Test only the control range and let anything else copy through as
+         * upstream did, or a tolerated invalid byte followed by more text is
+         * misreported as a control character. */
         if (src >= eof) return_err(src, "unclosed string");
-        return_err(src, "unexpected control character in string");
+        if (unlikely(*src < 0x20)) {
+            return_err(src, "unexpected control character in string");
+        }
+        *dst++ = *src++;
     }
 
 copy_ascii:


### PR DESCRIPTION
Post-0.6.0 review of the ~30 changes on master. Three defects, seven beads (`fj-tmb`, `fj-syj`, `fj-npb`, `fj-zfz`, `fj-flh`, `fj-q3f`, `fj-x3p`).

## Fixed

**P-004 rejected too much** (`vendor/yyjson/yyjson.c`). The patch replaced yyjson's `copy_escape` fall-through with an unconditional error, assuming only control characters reach that arm. They don't: `copy_utf8` sends a byte tolerated by `ALLOW_INVALID_UNICODE` to `copy_ascii_stop_1`, which copies it and re-enters `copy_utf8`, so the next ordinary ASCII byte arrives via `goto copy_escape`. Any string with both a backslash escape and an invalid UTF-8 byte followed by text failed under `JSON_INVALID_UTF8_IGNORE`/`SUBSTITUTE`: `"\/\xFFe"` reported `unexpected control character in string` where `json_decode` returns `/e`. The arm now tests the control range and keeps upstream's byte copy. Shipped in 0.6.0, so not a regression from this cycle.

**The encoder kept walking after a hard stop** (`fastjson_directwrite.c`). The discard walk discarded its own return value, so an error nested inside the failing container never ended it. `fastjson_encode([[INF, "\xB1\x31"], INF])` reported `JSON_ERROR_INF_OR_NAN` where `json_encode` reports `JSON_ERROR_UTF8`, and `jsonSerialize()` ran on values ext/json never reaches. Probe matrix 9/12 to 12/12 on both error code and callback count. 0.6.0 fails 12/12, so this completes fj-dpj and fj-2pu rather than reverting them.

**The 1 MiB exact-size preflight cost more than it saved** (`php_fastjson.h`). Above `FASTJSON_EXACT_NONASCII_THRESHOLD` a non-copyable-ASCII string paid a second full pass to size the output exactly; for UTF-8 that pass costs about as much as the write. Raised to 8 MiB, where the avoided 6x reservation (48 MiB) starts to threaten a default `memory_limit`.

| case | x86_64 vs 0.6.0 | aarch64 vs 0.6.0 |
|---|---:|---:|
| `encode_unicode_1m` | +75% → **-3.8%** | +160% → **-1.1%** |
| `encode_escaped_1m` | +44% → **-1.7%** | +73% → **-1.0%** |
| `encode_ascii_1m` (win kept) | -61.3% | -39.2% |

## Measured and kept

The 256 KiB string threshold costs aarch64 8% on clean 256 KiB ASCII while winning 35% on x86_64; P-005 costs aarch64 9% on strict string validation while winning 58% on tolerant decode. Both trades are now recorded next to the code.

## Also

`[Unreleased]` changelog written from the closed-bead set (it documented 2 of ~30 changes), and `bench/review-baseline.md` committed with the interleaved A/B recipe. Running the two builds alternately in one session is what surfaced the encode regression; sequential runs drift up to 40% on the same binary.

## Verification

- 185 PHPTs green on x86_64 release, under ASAN/UBSAN/LSAN on ZTS with zero diagnostics, and on aarch64
- Encode fuzz 7,601 cases and decode fuzz 255,843 cases unchanged against ext/json; validate/decode/`json_validate` agreement went from 1 disagreement over 6,015 inputs to 0
- 41-case benchmark A/B against 0.6.0: no case worse than +4.2%
- yyjson patch series replays against pristine 0.12.0; project metadata check passes