### PR TITLE
Explain why the two discard-resume indexes are spelled differently

### DIFF
--- a/fastjson_directwrite.c
+++ b/fastjson_directwrite.c
@@ -550,6 +550,14 @@ static zend_never_inline bool dw_emit_array(fastjson_dw_ctx *ctx, HashTable *ht,
             if (UNEXPECTED(!dw_encode_zval(
                     ctx, item, remaining_depth - 1))) {
                 if (ctx->hard_error && !ctx->discard_aborted) {
+                    /* Resume at the element after the one that failed.
+                     * ZEND_HASH_FOREACH_VAL expands to
+                     * _ZEND_HASH_FOREACH_VAL, which declares only `_z` (the
+                     * current element) and advances it in the loop's
+                     * increment -- hence the +1. The key/value loops use
+                     * ZEND_HASH_FOREACH_FROM instead, where `__z` is already
+                     * advanced and is not in scope here. The two spellings
+                     * are not interchangeable. */
 #if PHP_VERSION_ID < 80200
                     uint32_t from = (uint32_t)((_p + 1) - __ht->arData);
 #else
@@ -579,6 +587,8 @@ static zend_never_inline bool dw_emit_array(fastjson_dw_ctx *ctx, HashTable *ht,
             if (UNEXPECTED(!dw_emit_object_key(ctx, key, index)
                     || !dw_encode_zval(ctx, item, remaining_depth - 1))) {
                 if (ctx->hard_error && !ctx->discard_aborted) {
+                    /* `__z` is pre-advanced by ZEND_HASH_FOREACH_FROM, so it
+                     * already names the next element; no +1 here. */
 #if PHP_VERSION_ID < 80200
                     uint32_t from = (uint32_t)((_p + 1) - __ht->arData);
 #else
@@ -825,6 +835,8 @@ static bool dw_emit_object_props(fastjson_dw_ctx *ctx, zval *zv,
         if (UNEXPECTED(!dw_emit_object_key(ctx, key, index)
                 || !dw_encode_zval(ctx, item, remaining_depth - 1))) {
             if (ctx->hard_error && !ctx->discard_aborted) {
+                /* `__z` is pre-advanced by ZEND_HASH_FOREACH_FROM, so it
+                 * already names the next element; no +1 here. */
 #if PHP_VERSION_ID < 80200
                 uint32_t from = (uint32_t)((_p + 1) - __ht->arData);
 #else


### PR DESCRIPTION
Comments only. The compiled `.text` section is byte-identical to `71ff9c9` (verified with `objcopy --only-section=.text` + `cmp`).

`dw_emit_array`'s list branch computes the resume index as `_z + 1`; its key/value branch and `dw_emit_object_props` use a bare `__z`. That reads like an inconsistency, and I tried to unify it during a simplification pass. It doesn't compile:

| loop macro | expands to | cursor in scope | position |
|---|---|---|---|
| `ZEND_HASH_FOREACH_VAL` | `_ZEND_HASH_FOREACH_VAL` | `_z` only | current element, advanced in the loop increment |
| `ZEND_HASH_FOREACH_KEY_VAL` | `ZEND_HASH_FOREACH_FROM` | `_z` and `__z` | `__z` pre-advanced at the top of the body |

So the `+1` is required in one branch and wrong in the other, and `__z` is not in scope in the list branch at all. Getting this wrong silently changes which sibling the post-hard-error discard walk resumes at, which is what `tests/encode_error_precedence_abort.phpt` pins.

Suite green (183 passed / 2 skipped / 0 failed) and the discard oracles are 12/12 and 6/6, unchanged.